### PR TITLE
Add YOLO TXT annotation support for detection datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Check the `detection_configs` directory to know more about setting up the config
 
 Check [this dataset on Kaggle](https://www.kaggle.com/datasets/sovitrath/voc-07-12) to know how the images and masks are structured.
 
+*New:* the detection configuration files accept an `ANNOT_FORMAT` key that controls how bounding boxes are read. Set it to `pascal_voc` (default) for XML annotations or to `yolo_txt` when working with YOLO formatted `.txt` label files. Point the `TRAIN_ANNOT` and `VALID_ANNOT` paths to the corresponding annotation directories.
+
 [Check this](https://github.com/facebookresearch/dinov3?tab=readme-ov-file#pretrained-backbones-via-pytorch-hub) to know all the `--model-name` values that can be passed (e.g. `dinov3_vits16`, etc.).
 
 The training pipeline supports building detection head with SSD and RetinaNet. RetinaNet is default is gives much better results.

--- a/detection_configs/coco.yaml
+++ b/detection_configs/coco.yaml
@@ -21,3 +21,6 @@ CLASSES: [
 
 # Whether to visualize images after crearing the data loaders.
 VISUALIZE_TRANSFORMED_IMAGES: false
+
+# Annotation format. Supported values: pascal_voc, yolo_txt.
+ANNOT_FORMAT: pascal_voc

--- a/detection_configs/voc.yaml
+++ b/detection_configs/voc.yaml
@@ -15,3 +15,6 @@ CLASSES: [
 
 # Whether to visualize images after crearing the data loaders.
 VISUALIZE_TRANSFORMED_IMAGES: false
+
+# Annotation format. Supported values: pascal_voc, yolo_txt.
+ANNOT_FORMAT: pascal_voc

--- a/detection_configs/voc_mini.yaml
+++ b/detection_configs/voc_mini.yaml
@@ -15,3 +15,6 @@ CLASSES: [
 
 # Whether to visualize images after crearing the data loaders.
 VISUALIZE_TRANSFORMED_IMAGES: false
+
+# Annotation format. Supported values: pascal_voc, yolo_txt.
+ANNOT_FORMAT: pascal_voc

--- a/src/detection/datasets.py
+++ b/src/detection/datasets.py
@@ -10,14 +10,24 @@ from src.detection.custom_utils import collate_fn, get_train_transform, get_vali
 
 # The dataset class.
 class CustomDataset(Dataset):
+    SUPPORTED_ANNOTATION_FORMATS = {
+        'pascal_voc': 'pascal_voc',
+        'voc': 'pascal_voc',
+        'xml': 'pascal_voc',
+        'yolo': 'yolo_txt',
+        'yolo_txt': 'yolo_txt',
+        'txt': 'yolo_txt',
+    }
+
     def __init__(
-            self, 
-            img_path, 
-            annot_path, 
-            width, 
-            height, 
-            classes, 
-            transforms=None
+            self,
+            img_path,
+            annot_path,
+            width,
+            height,
+            classes,
+            transforms=None,
+            annotation_format='pascal_voc'
     ):
         self.transforms = transforms
         self.img_path = img_path
@@ -27,6 +37,15 @@ class CustomDataset(Dataset):
         self.classes = classes
         self.image_file_types = ['*.jpg', '*.jpeg', '*.png', '*.ppm', '*.JPG']
         self.all_image_paths = []
+
+        annotation_format = annotation_format.lower()
+        if annotation_format not in self.SUPPORTED_ANNOTATION_FORMATS:
+            raise ValueError(
+                f"Unsupported annotation format: {annotation_format}. "
+                f"Supported formats are: {list(self.SUPPORTED_ANNOTATION_FORMATS.keys())}"
+            )
+        self.annotation_format = self.SUPPORTED_ANNOTATION_FORMATS[annotation_format]
+        self.background_offset = 1 if len(self.classes) > 0 and self.classes[0] == '__background__' else 0
         
         # Get all the image paths in sorted order.
         for file_type in self.image_file_types:
@@ -46,54 +65,32 @@ class CustomDataset(Dataset):
         image_resized /= 255.0
         
         # Capture the corresponding XML file for getting the annotations.
-        annot_filename = os.path.splitext(image_name)[0] + '.xml'
+        if self.annotation_format == 'pascal_voc':
+            annot_filename = os.path.splitext(image_name)[0] + '.xml'
+        else:
+            annot_filename = os.path.splitext(image_name)[0] + '.txt'
         annot_file_path = os.path.join(self.annot_path, annot_filename)
-        
+
         boxes = []
         labels = []
-        tree = et.parse(annot_file_path)
-        root = tree.getroot()
-        
         # Original image width and height.
         image_width = image.shape[1]
         image_height = image.shape[0]
-        
-        # Box coordinates for xml files are extracted 
-        # and corrected for image size given.
-        for member in root.findall('object'):
-            # Get label and map the `classes`.
-            labels.append(self.classes.index(member.find('name').text))
-            
-            # Left corner x-coordinates.
-            xmin = int(member.find('bndbox').find('xmin').text)
-            # Right corner x-coordinates.
-            xmax = int(member.find('bndbox').find('xmax').text)
-            # Left corner y-coordinates.
-            ymin = int(member.find('bndbox').find('ymin').text)
-            # Right corner y-coordinates.
-            ymax = int(member.find('bndbox').find('ymax').text)
-            
-            # Resize the bounding boxes according 
-            # to resized image `width`, `height`.
-            xmin_final = (xmin/image_width)*self.width
-            xmax_final = (xmax/image_width)*self.width
-            ymin_final = (ymin/image_height)*self.height
-            ymax_final = (ymax/image_height)*self.height
 
-            # Check that max coordinates are at least one pixel
-            # larger than min coordinates.
-            if xmax_final == xmin_final:
-                xmin_final -= 1
-            if ymax_final == ymin_final:
-                ymin_final -= 1
-            # Check that all coordinates are within the image.
-            if xmax_final > self.width:
-                xmax_final = self.width
-            if ymax_final > self.height:
-                ymax_final = self.height
-            
-            boxes.append([xmin_final, ymin_final, xmax_final, ymax_final])
-        
+        if os.path.exists(annot_file_path):
+            if self.annotation_format == 'pascal_voc':
+                boxes, labels = self._parse_voc_annotation(
+                    annot_file_path,
+                    image_width,
+                    image_height
+                )
+            else:
+                boxes, labels = self._parse_yolo_annotation(
+                    annot_file_path,
+                    image_width,
+                    image_height
+                )
+
         # Bounding box to tensor.
         boxes = torch.as_tensor(boxes, dtype=torch.float32)
         # Area of the bounding boxes.
@@ -120,33 +117,137 @@ class CustomDataset(Dataset):
             image_resized = sample['image']
             target['boxes'] = torch.Tensor(sample['bboxes'])
             target['labels'] = torch.as_tensor(sample['labels'], dtype=torch.int64)
-        
+            if target['boxes'].shape[0] > 0:
+                target['area'] = (target['boxes'][:, 3] - target['boxes'][:, 1]) * (
+                    target['boxes'][:, 2] - target['boxes'][:, 0]
+                )
+            else:
+                target['area'] = torch.zeros((0,), dtype=torch.float32)
+            target['iscrowd'] = torch.zeros((target['boxes'].shape[0],), dtype=torch.int64)
+        else:
+            target['labels'] = torch.as_tensor(labels, dtype=torch.int64)
+
         if np.isnan((target['boxes']).numpy()).any() or target['boxes'].shape == torch.Size([0]):
             target['boxes'] = torch.zeros((0, 4), dtype=torch.int64)
         return image_resized, target
+
+    def _rescale_and_clip_box(self, xmin, ymin, xmax, ymax, image_width, image_height):
+        xmin_final = (xmin / image_width) * self.width
+        xmax_final = (xmax / image_width) * self.width
+        ymin_final = (ymin / image_height) * self.height
+        ymax_final = (ymax / image_height) * self.height
+
+        xmin_final = max(min(xmin_final, self.width), 0)
+        xmax_final = max(min(xmax_final, self.width), 0)
+        ymin_final = max(min(ymin_final, self.height), 0)
+        ymax_final = max(min(ymax_final, self.height), 0)
+
+        if xmax_final <= xmin_final:
+            xmax_final = min(xmin_final + 1, self.width)
+        if ymax_final <= ymin_final:
+            ymax_final = min(ymin_final + 1, self.height)
+
+        return [xmin_final, ymin_final, xmax_final, ymax_final]
+
+    def _parse_voc_annotation(self, annot_file_path, image_width, image_height):
+        boxes = []
+        labels = []
+        tree = et.parse(annot_file_path)
+        root = tree.getroot()
+
+        for member in root.findall('object'):
+            label_name = member.find('name').text
+            if label_name not in self.classes:
+                continue
+            labels.append(self.classes.index(label_name))
+
+            xmin = int(member.find('bndbox').find('xmin').text)
+            xmax = int(member.find('bndbox').find('xmax').text)
+            ymin = int(member.find('bndbox').find('ymin').text)
+            ymax = int(member.find('bndbox').find('ymax').text)
+
+            boxes.append(
+                self._rescale_and_clip_box(
+                    xmin,
+                    ymin,
+                    xmax,
+                    ymax,
+                    image_width,
+                    image_height
+                )
+            )
+        return boxes, labels
+
+    def _parse_yolo_annotation(self, annot_file_path, image_width, image_height):
+        boxes = []
+        labels = []
+        with open(annot_file_path, 'r') as annot_file:
+            for line in annot_file.readlines():
+                line = line.strip()
+                if not line:
+                    continue
+                parts = line.split()
+                if len(parts) < 5:
+                    continue
+
+                class_id = int(float(parts[0])) + self.background_offset
+                if class_id < 0 or class_id >= len(self.classes):
+                    continue
+
+                x_center = float(parts[1])
+                y_center = float(parts[2])
+                width = float(parts[3])
+                height = float(parts[4])
+
+                if max(abs(x_center), abs(y_center), abs(width), abs(height)) <= 1.0:
+                    x_center *= image_width
+                    y_center *= image_height
+                    width *= image_width
+                    height *= image_height
+
+                xmin = x_center - (width / 2)
+                ymin = y_center - (height / 2)
+                xmax = x_center + (width / 2)
+                ymax = y_center + (height / 2)
+
+                boxes.append(
+                    self._rescale_and_clip_box(
+                        xmin,
+                        ymin,
+                        xmax,
+                        ymax,
+                        image_width,
+                        image_height
+                    )
+                )
+                labels.append(class_id)
+
+        return boxes, labels
 
     def __len__(self):
         return len(self.all_images)
 
 # Prepare the final datasets and data loaders.
-def create_train_dataset(img_dir, annot_dir, classes, resize=(640, 640)):
+def create_train_dataset(img_dir, annot_dir, classes, resize=(640, 640), annotation_format='pascal_voc'):
     train_dataset = CustomDataset(
-        img_dir, 
-        annot_dir, 
-        resize[0], 
-        resize[1], 
-        classes, 
-        get_train_transform()
+        img_dir,
+        annot_dir,
+        resize[0],
+        resize[1],
+        classes,
+        get_train_transform(),
+        annotation_format=annotation_format
     )
     return train_dataset
-def create_valid_dataset(img_dir, annot_dir, classes, resize=(640, 640)):
+def create_valid_dataset(img_dir, annot_dir, classes, resize=(640, 640), annotation_format='pascal_voc'):
     valid_dataset = CustomDataset(
-        img_dir, 
-        annot_dir, 
-        resize[0], 
-        resize[1], 
-        classes, 
-        get_valid_transform()
+        img_dir,
+        annot_dir,
+        resize[0],
+        resize[1],
+        classes,
+        get_valid_transform(),
+        annotation_format=annotation_format
     )
     return valid_dataset
 def create_train_loader(train_dataset, batch_size, num_workers=0):
@@ -198,15 +299,17 @@ if __name__ == '__main__':
     VALID_IMG = config['VALID_IMG']
     VALID_ANNOT = config['VALID_ANNOT']
     CLASSES = config['CLASSES']
+    ANNOT_FORMAT = config.get('ANNOT_FORMAT', 'pascal_voc')
 
     # sanity check of the Dataset pipeline with sample visualization
     dataset = CustomDataset(
-        TRAIN_IMG, 
-        TRAIN_ANNOT, 
-        640, 
-        640, 
+        TRAIN_IMG,
+        TRAIN_ANNOT,
+        640,
+        640,
         CLASSES,
-        get_train_transform()
+        get_train_transform(),
+        annotation_format=ANNOT_FORMAT
     )
     print(f"Number of training images: {len(dataset)}")
     

--- a/train_detection.py
+++ b/train_detection.py
@@ -161,6 +161,7 @@ VALID_ANNOT = config['VALID_ANNOT']
 CLASSES = config['CLASSES']
 NUM_CLASSES = len(CLASSES)
 VISUALIZE_TRANSFORMED_IMAGES = config['VISUALIZE_TRANSFORMED_IMAGES']
+ANNOT_FORMAT = config.get('ANNOT_FORMAT', 'pascal_voc')
 
 DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
@@ -236,9 +237,11 @@ if __name__ == '__main__':
     os.makedirs(OUT_DIR, exist_ok=True)
     train_dataset = create_train_dataset(
         TRAIN_IMG, TRAIN_ANNOT, CLASSES, args.imgsz,
+        annotation_format=ANNOT_FORMAT
     )
     valid_dataset = create_valid_dataset(
-        VALID_IMG, VALID_ANNOT, CLASSES, args.imgsz
+        VALID_IMG, VALID_ANNOT, CLASSES, args.imgsz,
+        annotation_format=ANNOT_FORMAT
     )
     train_loader = create_train_loader(
         train_dataset=train_dataset, 


### PR DESCRIPTION
## Summary
- add support for YOLO-format TXT annotations in the detection dataset loader and keep metadata consistent after transforms
- expose an `ANNOT_FORMAT` option in detection configs and documentation to switch between Pascal VOC XML and YOLO TXT labels

## Testing
- python -m compileall -f src/detection/datasets.py train_detection.py

------
https://chatgpt.com/codex/tasks/task_e_68dd3554cadc8322a295dfcf189a3019